### PR TITLE
Changed some functions that don't modify their arg to take const arg.

### DIFF
--- a/include/libestr.h
+++ b/include/libestr.h
@@ -202,11 +202,11 @@ es_strdup(es_str_t *str)
  * @param[in] len lenght of buffer
  * @returns 0 if equal, negative if s<cs, positive if s>cs
 */
-int es_strbufcmp(es_str_t *s, unsigned char *b, es_size_t len);
+int es_strbufcmp(es_str_t *s, const unsigned char *b, es_size_t len);
 
 /** Case-insensitive version of es_strcasebufcmp.
  */
-int es_strcasebufcmp(es_str_t *s, unsigned char *b, es_size_t len);
+int es_strcasebufcmp(es_str_t *s, const unsigned char *b, es_size_t len);
 
 
 /**
@@ -305,7 +305,7 @@ int es_extendBuf(es_str_t **ps, es_size_t minNeeded);
  * @param[in/out] ps string to be extened (updatedable pointer required!)
  * @returns 0 on success, something else otherwise
  */
-int es_addChar(es_str_t **ps, unsigned char c);
+int es_addChar(es_str_t **ps, const unsigned char c);
 
 
 /**
@@ -318,7 +318,7 @@ int es_addChar(es_str_t **ps, unsigned char c);
  *
  * @returns 0 on success, something else otherwise
  */
-int es_addBuf(es_str_t **ps1, char *buf, es_size_t lenBuf);
+int es_addBuf(es_str_t **ps1, const char *buf, const es_size_t lenBuf);
 
 /**
  * A macro to add a traditional C constant to a string.
@@ -361,7 +361,7 @@ es_addStr(es_str_t **ps1, es_str_t *s2)
  * 	This string is allocated from the dynamic memory pool and must be freed
  * 	by the caller.
  */
-char *es_str2cstr(es_str_t *s, char *nulEsc);
+char *es_str2cstr(es_str_t *s, const char *nulEsc);
 
 /**
  * Obtain a number from the string object. The result is always valid

--- a/src/string.c
+++ b/src/string.c
@@ -237,7 +237,7 @@ es_deleteStr(es_str_t *s)
 
 
 int
-es_strbufcmp(es_str_t *s, unsigned char *buf, es_size_t lenBuf)
+es_strbufcmp(es_str_t *s, const unsigned char *buf, es_size_t lenBuf)
 {
 	int r;
 	es_size_t i;
@@ -270,7 +270,7 @@ es_strbufcmp(es_str_t *s, unsigned char *buf, es_size_t lenBuf)
  * call, so change propagation is easy ;)
  */
 int
-es_strcasebufcmp(es_str_t *s, unsigned char *buf, es_size_t lenBuf)
+es_strcasebufcmp(es_str_t *s, const unsigned char *buf, es_size_t lenBuf)
 {
 	int r;
 	es_size_t i;
@@ -443,7 +443,7 @@ done:	return r;
 
 
 int
-es_addChar(es_str_t **ps, unsigned char c)
+es_addChar(es_str_t **ps, const unsigned char c)
 {
 	int r = 0;
 
@@ -460,7 +460,7 @@ done:
 
 
 int
-es_addBuf(es_str_t **ps1, char *buf, es_size_t lenBuf)
+es_addBuf(es_str_t **ps1, const char *buf, es_size_t lenBuf)
 {
 	int r;
 	es_size_t newlen;
@@ -494,7 +494,7 @@ done:
 
 
 char *
-es_str2cstr(es_str_t *s, char *nulEsc)
+es_str2cstr(es_str_t *s, const char *nulEsc)
 {
 	char *cstr;
 	es_size_t lenEsc;


### PR DESCRIPTION
It avoids caller having to strdup to create (char_) from (const char_).

Some new lognorm work builds on top of this. Without this a lot of unnecessary string-copying would be required.
