### PR TITLE
bugfix: es_str2num mishandling empty strings

### DIFF
--- a/src/string.c
+++ b/src/string.c
@@ -607,10 +607,10 @@ es_str2num(es_str_t *s, int *bSuccess)
 {
 	long long num;
 	unsigned char *c;
-
 	if(s->lenStr == 0) {
 		num = 0;
-		*bSuccess = 0;
+		if(bSuccess != NULL)
+			*bSuccess = 0;
 		goto done;
 	}
 


### PR DESCRIPTION
If es_str2num() receives an empty string, misadressing happens.
Under extreme conditions, this theoretically can lead to a segfault.

closes https://github.com/rsyslog/libestr/issues/10