### PR TITLE
portability: remove issues associated with AC_FUNC_MALLOC

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -63,7 +63,6 @@ AC_SUBST(rt_libs)
 #AC_STRUCT_TM
 
 # Checks for library functions.
-AC_FUNC_MALLOC
 #AC_FUNC_SELECT_ARGTYPES
 #AC_TYPE_SIGNAL
 #AC_CHECK_FUNCS([])


### PR DESCRIPTION
This configure.ac macro is known to cause issues and not provide real
benefit. Thus many projects have removed it, as we have for most of
the rsyslog projects. libestr seemed to have overlooked.

This came up when troubleshooting issues on IBM AIX.